### PR TITLE
Added Swagger With versioning and also used Scalar intergrated with OpenAPI

### DIFF
--- a/Gym.Tracker.API/Controllers/v1/WeatherForecastController.cs
+++ b/Gym.Tracker.API/Controllers/v1/WeatherForecastController.cs
@@ -1,9 +1,11 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Gym.Tracker.API.Controllers
+namespace Gym.Tracker.API.Controllers.v1
 {
     [ApiController]
-    [Route("[controller]")]
+    [Route("api/v{version:apiVersion}/[Controller]")]
+    [ApiVersion("1.0")]
     public class WeatherForecastController : ControllerBase
     {
         private static readonly string[] Summaries = new[]

--- a/Gym.Tracker.API/Controllers/v2/WeatherForecastController.cs
+++ b/Gym.Tracker.API/Controllers/v2/WeatherForecastController.cs
@@ -1,0 +1,35 @@
+using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Gym.Tracker.API.Controllers.v2
+{
+    [ApiController]
+    [Route("api/v{version:apiVersion}/[Controller]")]
+    [ApiVersion("2.0")]
+    public class WeatherForecastController : ControllerBase
+    {
+        private static readonly string[] Summaries = new[]
+        {
+            "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+        };
+
+        private readonly ILogger<WeatherForecastController> _logger;
+
+        public WeatherForecastController(ILogger<WeatherForecastController> logger)
+        {
+            _logger = logger;
+        }
+
+        [HttpGet(Name = "GetWeatherForecast")]
+        public IEnumerable<WeatherForecast> Get()
+        {
+            return Enumerable.Range(1, 5).Select(index => new WeatherForecast
+            {
+                Date = DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
+                TemperatureC = Random.Shared.Next(-20, 55),
+                Summary = Summaries[Random.Shared.Next(Summaries.Length)]
+            })
+            .ToArray();
+        }
+    }
+}

--- a/Gym.Tracker.API/Gym.Tracker.API.csproj
+++ b/Gym.Tracker.API/Gym.Tracker.API.csproj
@@ -10,4 +10,9 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.8" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Gym.Tracker.Common\Gym.Tracker.Common.csproj" />
+    <ProjectReference Include="..\Gym.Tracker.Core\Gym.Tracker.Core.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/Gym.Tracker.API/Program.cs
+++ b/Gym.Tracker.API/Program.cs
@@ -1,19 +1,62 @@
+using Auth.Learn.Common.Extensions;
+using Scalar.AspNetCore;
+using System;
+
 var builder = WebApplication.CreateBuilder(args);
 
+
+//Enable CORS
+builder.Services.AddCors(options => options.AddDefaultPolicy(builder =>
+{
+    builder.WithOrigins("*")
+    .AllowAnyMethod()
+    .AllowAnyHeader();
+}));
 // Add services to the container.
 
 builder.Services.AddControllers();
-// Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
-builder.Services.AddOpenApi();
 
+builder.Services.RegisterApiVersioningServices();
+
+//Register Swagger
+builder.Services.RegisterSwaggerAuthorization("Gym.Tracker.Api.xml");
+
+//Add OpenAPI
+//builder.Services.AddOpenApi();
+
+builder.Services.AddRouting();
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {
+    app.UseSwagger();
     app.MapOpenApi();
+
+    app.UseSwaggerUI(swagger =>
+    {
+        swagger.SwaggerEndpoint("/swagger/v1/swagger.json", "Gym Tracker API V1");
+        swagger.SwaggerEndpoint("/swagger/v2/swagger.json", "Gym Tracker API V2");
+    });
+
+    //string[] versions = ["v1", "v2"];
+    //app.MapScalarApiReference(options =>
+    //{
+    //    options.AddDocuments(versions.Select(version => new ScalarDocument(version, $"Gym Tracker API {version}")));
+    //    options.WithTitle("Scalar API");
+    //    options.WithTheme(ScalarTheme.Solarized);
+    //    options.WithDownloadButton(true);
+    //});
+
 }
 
+app.UseCors(x => x
+               .AllowAnyMethod()
+               .AllowAnyHeader()
+               .SetIsOriginAllowed(origin => true) // allow any origin
+               .AllowCredentials());
+
+app.UseRouting();
 app.UseHttpsRedirection();
 
 app.UseAuthorization();

--- a/Gym.Tracker.API/Properties/launchSettings.json
+++ b/Gym.Tracker.API/Properties/launchSettings.json
@@ -1,23 +1,38 @@
-﻿{
-  "$schema": "https://json.schemastore.org/launchsettings.json",
+{
   "profiles": {
     "http": {
       "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": false,
-      "applicationUrl": "http://localhost:5090",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      }
+      },
+      "dotnetRunMessages": true,
+      "applicationUrl": "http://localhost:5090"
     },
     "https": {
       "commandName": "Project",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
       "dotnetRunMessages": true,
-      "launchBrowser": false,
-      "applicationUrl": "https://localhost:7010;http://localhost:5090",
+      "applicationUrl": "https://localhost:7010;http://localhost:5090"
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
+    }
+  },
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:55301/",
+      "sslPort": 44333
     }
   }
 }

--- a/Gym.Tracker.Common/Class1.cs
+++ b/Gym.Tracker.Common/Class1.cs
@@ -1,7 +1,0 @@
-﻿namespace Gym.Tracker.Common
-{
-    public class Class1
-    {
-
-    }
-}

--- a/Gym.Tracker.Common/Extensions/ApiVersionExtension.cs
+++ b/Gym.Tracker.Common/Extensions/ApiVersionExtension.cs
@@ -1,0 +1,33 @@
+﻿using Asp.Versioning;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Auth.Learn.Common.Extensions
+{
+    public static class ApiVersionExtension
+    {
+        /// <summary>
+        /// Register api version
+        /// </summary>
+        /// <param name="services"></param>
+        public static void RegisterApiVersioningServices(this IServiceCollection services)
+        {
+            services.AddApiVersioning(options =>
+            {
+                options.DefaultApiVersion = new ApiVersion(1, 0);
+                options.AssumeDefaultVersionWhenUnspecified = true;
+                options.ReportApiVersions = true;
+
+                // You can combine readers (URL, Query, Header, MediaType)
+                options.ApiVersionReader = ApiVersionReader.Combine(
+                    new UrlSegmentApiVersionReader()
+                // new QueryStringApiVersionReader("api-version"),
+                // new HeaderApiVersionReader("x-api-version")
+                );
+            }).AddApiExplorer(options =>
+            {
+                options.GroupNameFormat = "'v'V";  // e.g. v1, v1.1, v2
+                options.SubstituteApiVersionInUrl = true;
+            });
+        }
+    }
+}

--- a/Gym.Tracker.Common/Extensions/SwaggerExtension.cs
+++ b/Gym.Tracker.Common/Extensions/SwaggerExtension.cs
@@ -1,0 +1,80 @@
+﻿using Asp.Versioning.ApiExplorer;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Models;
+
+namespace Auth.Learn.Common.Extensions
+{
+    public static class SwaggerExtensions
+    {
+        /// <summary>
+        /// Register Swagger with API versioning
+        /// </summary>
+        public static void RegisterSwaggerAuthorization(this IServiceCollection services, string xmlDocumentationFileName)
+        {
+            services.AddEndpointsApiExplorer();
+
+            services.AddSwaggerGen(c =>
+            {
+                // Add JWT Bearer support
+                c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+                {
+                    In = ParameterLocation.Header,
+                    Description = "Please insert JWT with Bearer into field",
+                    Name = "Authorization",
+                    Type = SecuritySchemeType.ApiKey
+                });
+
+                c.AddSecurityRequirement(new OpenApiSecurityRequirement
+                {
+                    {
+                        new OpenApiSecurityScheme
+                        {
+                            Reference = new OpenApiReference
+                            {
+                                Type = ReferenceType.SecurityScheme,
+                                Id = "Bearer"
+                            }
+                        },
+                        Array.Empty<string>()
+                    }
+                });
+
+                // Include XML comments if available
+                var xmlPath = Path.Combine(AppContext.BaseDirectory, xmlDocumentationFileName);
+                if (File.Exists(xmlPath))
+                {
+                    c.IncludeXmlComments(xmlPath);
+                }
+            });
+
+            // Hook into versioned API explorer so swagger generates docs per API version
+            services.ConfigureOptions<SwaggerVersioningOptions>();
+        }
+    }
+
+    /// <summary>
+    /// Configures Swagger docs for each API version
+    /// </summary>
+    public class SwaggerVersioningOptions : Microsoft.Extensions.Options.IConfigureOptions<Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions>
+    {
+        private readonly IApiVersionDescriptionProvider _provider;
+
+        public SwaggerVersioningOptions(IApiVersionDescriptionProvider provider)
+        {
+            _provider = provider;
+        }
+
+        public void Configure(Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions options)
+        {
+            foreach (var desc in _provider.ApiVersionDescriptions)
+            {
+                options.SwaggerDoc(desc.GroupName, new OpenApiInfo
+                {
+                    Title = "Gym Tracker",
+                    Version = desc.ApiVersion.ToString(),
+                    Description = "API documentation with versioning support"
+                });
+            }
+        }
+    }
+}

--- a/Gym.Tracker.Common/Gym.Tracker.Common.csproj
+++ b/Gym.Tracker.Common/Gym.Tracker.Common.csproj
@@ -6,4 +6,13 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Asp.Versioning.Http" Version="8.1.0" />
+    <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
+    <PackageReference Include="Scalar.AspNetCore" Version="2.7.4" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="9.0.4" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="9.0.4" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="9.0.4" />
+  </ItemGroup>
+
 </Project>

--- a/Gym.Tracker.Core/Class1.cs
+++ b/Gym.Tracker.Core/Class1.cs
@@ -1,7 +1,0 @@
-﻿namespace Gym.Tracker.Core
-{
-    public class Class1
-    {
-
-    }
-}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Introduced API versioning with v1 and v2 endpoints for WeatherForecast.
  * Added Swagger/OpenAPI with per-version documentation and JWT Bearer support.
  * Enabled a global, permissive CORS policy (any origin, method, headers; supports credentials).

* Chores
  * Updated startup configuration and routing; enabled Swagger UI in development with separate entries for v1 and v2.
  * Revised launch settings, added IIS Express profile, set HTTPS profile to open Swagger by default, and adjusted URLs/environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->